### PR TITLE
Copy linux npm executable in addition to cmd file

### DIFF
--- a/nvmw.bat
+++ b/nvmw.bat
@@ -184,6 +184,7 @@ if not exist "%NODE_EXE_FILE%" (
   rmdir /s /q "%NODE_HOME%\node_modules\npm"
   move npm-* "%NODE_HOME%\node_modules\npm"
   copy "%NODE_HOME%\node_modules\npm\bin\npm.cmd" "%NODE_HOME%\npm.cmd"
+  copy "%NODE_HOME%\node_modules\npm\bin\npm" "%NODE_HOME%\npm"
   cd "%CD_ORG%"
   if not exist "%NODE_HOME%\npm.cmd" goto install_error
   echo npm install ok


### PR DESCRIPTION
Starting from your PR I did a small change to copy the npm linux executable in addition to the Windows cmd file, so that CYGWIN/Mingw users can use npm too (from a Git Bash shell for example).

I realize it doesn't really fit into your PR but I needed both changes
